### PR TITLE
Set slave password to match master for templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ mysql-multi Cookbook CHANGELOG
 This file is used to list changes made in each version of the mysql-multi
 cookbook.
 
+v1.3.3 (??????????)
+- Set the slave root password to match master since the sync will change it (Issue #21)
+- Fix serverspec tests. (PR #22)
+
 v1.3.2 (2014-08-01)
 - Don't fail hard on solo runs without proper attribute config
 - Better logic for error checking on empty slaves

--- a/recipes/_find_master.rb
+++ b/recipes/_find_master.rb
@@ -17,6 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+include_recipe 'chef-sugar'
+
 if Chef::Config[:solo]
   errmsg = 'This recipe uses search if master attribute is not set.  Chef Solo does not support search.'
   Chef::Log.warn(errmsg)
@@ -36,6 +38,7 @@ elsif node['mysql-multi']['master'].nil?
     Chef::Application.fatal!(errmsg, 1)
   else
     node.set['mysql-multi']['master'] = best_ip_for(master)
+    node.set['mysql']['server_root_password'] = master['mysql']['server_root_password']
   end
 else
   str_master = node['mysql-multi']['master']

--- a/recipes/mysql_master.rb
+++ b/recipes/mysql_master.rb
@@ -18,8 +18,8 @@
 # limitations under the License.
 #
 
-include_recipe 'mysql-multi'
 include_recipe 'mysql-multi::_find_slaves'
+include_recipe 'mysql-multi'
 
 # drop MySQL master specific configuration file
 template '/etc/mysql/conf.d/master.cnf' do

--- a/recipes/mysql_slave.rb
+++ b/recipes/mysql_slave.rb
@@ -18,8 +18,8 @@
 # limitations under the License.
 #
 
-include_recipe 'mysql-multi'
 include_recipe 'mysql-multi::_find_master'
+include_recipe 'mysql-multi'
 
 # drop MySQL slave specific configuration file
 template '/etc/mysql/conf.d/slave.cnf' do

--- a/test/integration/nodes/master01.json
+++ b/test/integration/nodes/master01.json
@@ -16,7 +16,8 @@
     ],
     "ipaddress": "192.168.0.23",
     "mysql": {
-      "server_repl_password": "guudpasswerd"
+      "server_repl_password": "guudpasswerd",
+      "server_root_password": "gimm3masterpassw3rd"
     }
   },
   "normal": {

--- a/test/integration/slave/serverspec/slave_spec.rb
+++ b/test/integration/slave/serverspec/slave_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative 'spec_helper'
 
-mysql_query = "mysql -uroot -pilikerandompasswords -B -e 'show slave status\\G'"
+mysql_query = "mysql -uroot -pgimm3masterpassw3rd -B -e 'show slave status\\G'"
 
 describe command(mysql_query) do
   it { should return_stdout(/Master_Host: 192\.168\.0\.23/) }
@@ -17,4 +17,8 @@ end
 
 describe file('/etc/mysql/conf.d/my.cnf') do
   it { should contain('server_id').from(/^\[mysqld\]/).to(/^\[mysqldump\]/) }
+end
+
+describe file('/root/.my.cnf') do
+  it { should contain('gimm3masterpassw3rd') }
 end


### PR DESCRIPTION
This should set the root password to match the master so templates will be
generated with the appropriate value.

closes #21
