### PR TITLE
MySQL template file poorly configured

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,3 +5,15 @@ default['mysql-multi']['slaves'] = %w()
 default['mysql-multi']['slave_user'] = 'replicant'
 default['mysql-multi']['server_repl_password'] = nil
 default['mysql-multi']['bind_ip'] = nil
+
+default['mysql-multi']['templates']['my.cnf']['cookbook'] = 'mysql-multi'
+default['mysql-multi']['templates']['my.cnf']['source'] = 'my.cnf.erb'
+
+default['mysql-multi']['templates']['user.my.cnf']['cookbook'] = 'mysql-multi'
+default['mysql-multi']['templates']['user.my.cnf']['source'] = 'user.my.cnf.erb'
+
+default['mysql-multi']['templates']['slave.cnf']['cookbook'] = 'mysql-multi'
+default['mysql-multi']['templates']['slave.cnf']['source'] = 'slave.cnf.erb'
+
+default['mysql-multi']['templates']['master.cnf']['cookbook'] = 'mysql-multi'
+default['mysql-multi']['templates']['master.cnf']['source'] = 'master.cnf.erb'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'christopher.coffey@rackspace.com'
 license 'Apache 2.0'
 description 'MySQL replication wrapper cookbook'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.3.5'
+version '1.4.0'
 
 supports 'ubuntu'
 supports 'centos'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -52,8 +52,8 @@ end
 
 # drop custom my.cnf file
 template '/etc/mysql/conf.d/my.cnf' do
-  cookbook 'mysql-multi'
-  source 'my.cnf.erb'
+  cookbook node['mysql-multi']['templates']['my.cnf']['cookbook']
+  source node['mysql-multi']['templates']['my.cnf']['source']
   variables(
     serverid: serverid,
     cookbook_name: cookbook_name,
@@ -64,8 +64,8 @@ end
 
 # add /root/.my.cnf file to system for local MySQL management
 template '/root/.my.cnf' do
-  cookbook 'mysql-multi'
-  source 'user.my.cnf.erb'
+  cookbook node['mysql-multi']['templates']['user.my.cnf']['cookbook']
+  source node['mysql-multi']['templates']['user.my.cnf']['source']
   owner 'root'
   group 'root'
   mode '0600'

--- a/recipes/mysql_master.rb
+++ b/recipes/mysql_master.rb
@@ -28,7 +28,8 @@ include_recipe 'mysql-multi'
 
 # drop MySQL master specific configuration file
 template '/etc/mysql/conf.d/master.cnf' do
-  source 'master.cnf.erb'
+  cookbook node['mysql-multi']['templates']['master.cnf']['cookbook']
+  source node['mysql-multi']['templates']['master.cnf']['source']
   variables(
     cookbook_name: cookbook_name
   )

--- a/recipes/mysql_slave.rb
+++ b/recipes/mysql_slave.rb
@@ -23,7 +23,8 @@ include_recipe 'mysql-multi'
 
 # drop MySQL slave specific configuration file
 template '/etc/mysql/conf.d/slave.cnf' do
-  source 'slave.cnf.erb'
+  cookbook node['mysql-multi']['templates']['slave.cnf']['cookbook']
+  source node['mysql-multi']['templates']['slave.cnf']['source']
   variables(
     cookbook_name: cookbook_name
   )


### PR DESCRIPTION
The MySQL template file used for building my.cnf is poorly optimized. While it works, it is configured in a way to severely limit database performance (e.g., "innodb_buffer_pool = 10M") and allow a database to fall over (e.g., "max_connections=2500"). We need to look at replacing it with a version similar to what is generated by a standard install of MySQL and tweaked for higher performance use. A better option would be a more configurable version where we can somewhat customize the various settings based on the expected workload.
