### PR TITLE
Minor fixes

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,8 +10,8 @@ provisioner:
     environment: dev
   attributes:
     mysql-multi:
-      master_ip: '192.168.0.1'
-      slave_ip: ['192.168.0.2', '192.168.0.3']
+      master: '192.168.0.1'
+      slaves: ['192.168.0.2', '192.168.0.3']
       server_repl_password: 'VeryBadReplPasswd'
       server_root_password: 'SillyRootPasswd'
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cookbook as well as the community MySQL cookbook have gone to a pure library des
 These recipes are provided for backwards compatibility and as examples of how to
 write wrapper recipes to utilize the libraries. They may be removed in later releases.
 
-`default.rb` : install a mysql server instance.
+`default.rb` : install a MySQL server instance.
 
 `mysql_master.rb` : sets up a master MySQL server and creates replicant users
 for each slave node defined within attributes.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ cookbook as well as the community MySQL cookbook have gone to a pure library des
 These recipes are provided for backwards compatibility and as examples of how to
 write wrapper recipes to utilize the libraries. They may be removed in later releases.
 
+`default.rb` : install a mysql server instance.
+
 `mysql_master.rb` : sets up a master MySQL server and creates replicant users
-for each slave node definded within attributes.
+for each slave node defined within attributes.
 
 When utilized, search will look for the node(s) in the same environment with the tag
 `mysql_slave` and grant the allowed replicating node(s). If you do not want to
@@ -36,7 +38,7 @@ use search, create the slave node(s) first before bootstrapping, and set the
 attribute `['mysql-multi']['master']` with the correct IP array.
 
 `mysql_slave.rb` : sets up a slave MySQL server pointing to the master node
-definded within attributes.
+defined within attributes.
 
 Search will look for the node in the same environment with the tag
 `mysql_master` and set master replication to that node. If you do not want to

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,6 +21,7 @@ default['mysql-multi']['templates']['master.cnf']['source'] = 'master.cnf.erb'
 # additional mysql namespace attributes needed for recipe since community
 # cookbook moved to version 6.x
 
+default['mysql-multi']['install_recipe'] = 'mysql-multi'
 default['mysql-multi']['server_root_password'] = nil
 default['mysql-multi']['service_name'] = 'chef'
 default['mysql-multi']['server_version'] = '5.5'

--- a/libraries/provider_slave_grants.rb
+++ b/libraries/provider_slave_grants.rb
@@ -14,7 +14,7 @@ class Chef
         require 'rubygems'
         require 'mysql2'
         begin
-          new_resource.slave_ip.each do |slave|
+          new_resource.slaves.each do |slave|
             grant_repl = "GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO '#{new_resource.user}"
             grant_repl += "'@'#{slave}' IDENTIFIED BY '#{new_resource.replpasswd}';"
             local_client.query(grant_repl)

--- a/libraries/resource_slave_grants.rb
+++ b/libraries/resource_slave_grants.rb
@@ -11,7 +11,7 @@ class Chef
       attribute :host, kind_of: String, default: '127.0.0.1'
       attribute :root_user, kind_of: String, default: 'root'
       attribute :rootpasswd, kind_of: String, required: true
-      attribute :slave_ip, kind_of: Array, required: true
+      attribute :slaves, kind_of: Array, required: true
       attribute :port, kind_of: String, default: '3306'
     end
   end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,3 +40,7 @@ end
 mysqlm_dot_my_cnf 'root' do
   passwd node['mysql-multi']['server_root_password']
 end
+
+mysql2_chef_gem 'default' do
+  action :install
+end

--- a/recipes/mysql_master.rb
+++ b/recipes/mysql_master.rb
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+include_recipe node['mysql-multi']['install_recipe']
 include_recipe 'mysql-multi::_find_slaves'
 
 # creates unique serverid via ipaddress to an int

--- a/recipes/mysql_master.rb
+++ b/recipes/mysql_master.rb
@@ -44,7 +44,7 @@ end
 mysqlm_slave_grants 'master' do
   replpasswd node['mysql-multi']['server_repl_password']
   rootpasswd node['mysql-multi']['server_root_password']
-  slave_ip node['mysql-multi']['slaves']
+  slaves node['mysql-multi']['slaves']
 end
 
 tag('mysql_master')

--- a/recipes/mysql_master.rb
+++ b/recipes/mysql_master.rb
@@ -18,10 +18,7 @@
 # limitations under the License.
 #
 
-include_recipe 'apt' if node.platform_family?('debian')
-include_recipe 'chef-sugar'
 include_recipe 'mysql-multi::_find_slaves'
-include_recipe 'mysql-multi'
 
 # creates unique serverid via ipaddress to an int
 require 'ipaddr'

--- a/recipes/mysql_master.rb
+++ b/recipes/mysql_master.rb
@@ -21,25 +21,12 @@
 include_recipe 'apt' if node.platform_family?('debian')
 include_recipe 'chef-sugar'
 include_recipe 'mysql-multi::_find_slaves'
-
-mysql2_chef_gem 'default' do
-  action :install
-end
-
-# set passwords dynamically...
-::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
-node.set_unless['mysql-multi']['server_root_password'] = secure_password
+include_recipe 'mysql-multi'
 
 # creates unique serverid via ipaddress to an int
 require 'ipaddr'
 serverid = IPAddr.new node['ipaddress']
 serverid = serverid.to_i
-
-# install mysql service
-mysql_service 'chef' do
-  initial_root_password node['mysql-multi']['server_root_password']
-  action [:create, :start]
-end
 
 # drop master.cnf configuration file
 mysql_config 'master replication' do

--- a/recipes/mysql_master.rb
+++ b/recipes/mysql_master.rb
@@ -44,7 +44,7 @@ end
 mysqlm_slave_grants 'master' do
   replpasswd node['mysql-multi']['server_repl_password']
   rootpasswd node['mysql-multi']['server_root_password']
-  slave_ip node['mysql-multi']['slave_ip']
+  slave_ip node['mysql-multi']['slaves']
 end
 
 # drop /root/.my.cnf file

--- a/recipes/mysql_master.rb
+++ b/recipes/mysql_master.rb
@@ -47,9 +47,4 @@ mysqlm_slave_grants 'master' do
   slave_ip node['mysql-multi']['slaves']
 end
 
-# drop /root/.my.cnf file
-mysqlm_dot_my_cnf 'root' do
-  passwd node['mysql-multi']['server_root_password']
-end
-
 tag('mysql_master')

--- a/recipes/mysql_slave.rb
+++ b/recipes/mysql_slave.rb
@@ -17,10 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-include_recipe 'apt' if node.platform_family?('debian')
 include_recipe 'mysql-multi::_find_master'
-include_recipe 'mysql-multi'
 
 # creates unique serverid via ipaddress to an int
 require 'ipaddr'

--- a/recipes/mysql_slave.rb
+++ b/recipes/mysql_slave.rb
@@ -46,9 +46,4 @@ mysqlm_slave_sync 'slaves' do
   master_ip node['mysql-multi']['master']
 end
 
-# drop .my.cnf file
-mysqlm_dot_my_cnf 'root' do
-  passwd node['mysql-multi']['server_root_password']
-end
-
 tag('mysql_slave')

--- a/recipes/mysql_slave.rb
+++ b/recipes/mysql_slave.rb
@@ -43,7 +43,7 @@ end
 mysqlm_slave_sync 'slaves' do
   replpasswd node['mysql-multi']['server_repl_password']
   rootpasswd node['mysql-multi']['server_root_password']
-  master_ip node['mysql-multi']['master_ip']
+  master_ip node['mysql-multi']['master']
 end
 
 # drop .my.cnf file

--- a/recipes/mysql_slave.rb
+++ b/recipes/mysql_slave.rb
@@ -20,25 +20,12 @@
 
 include_recipe 'apt' if node.platform_family?('debian')
 include_recipe 'mysql-multi::_find_master'
-
-mysql2_chef_gem 'default' do
-  action :install
-end
-
-# set passwords dynamically...
-::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
-node.set_unless['mysql-multi']['server_root_password'] = secure_password
+include_recipe 'mysql-multi'
 
 # creates unique serverid via ipaddress to an int
 require 'ipaddr'
 serverid = IPAddr.new node['ipaddress']
 serverid = serverid.to_i
-
-# install mysql service
-mysql_service 'chef' do
-  initial_root_password node['mysql-multi']['server_root_password']
-  action [:create, :start]
-end
 
 # drop slave.cnf configuration file
 mysql_config 'slave replication' do

--- a/recipes/mysql_slave.rb
+++ b/recipes/mysql_slave.rb
@@ -17,6 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+include_recipe node['mysql-multi']['install_recipe']
 include_recipe 'mysql-multi::_find_master'
 
 # creates unique serverid via ipaddress to an int


### PR DESCRIPTION
*Mysql Instance name*

In `mysql_master.rb` and `mysql_slave.rb` the attribute service name was ignored and 'chef' was hardcoded, there was no variables available (e.g. version, port, bind address etc). It made sense therefore to keeps things standard and bugfix at the same time - thus call default.rb

*Optional Mysql install*

To support custom MySQL installs (e.g. with more attributes like data_dir) the automatic inclusion of mysql-multi::default.rb was removed.

