### PR TITLE
Attribute for ServerID & mysql2_chef_gem version

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,12 @@ the slave MySQL user, by default it is set to 'replicant'.
 best `bind_address` for mysql. Allowing you to set it to whatever is needed for
 your specific configuration.
 
+`['mysql-multi']['install_recipe']` default behaviour is to install MySQL using 
+mysql-multi::default recipe, however this allows the use of your own custom recipe
+should you require alternative configuration (e.g. data directory). Default to 'mysql-multi'
+
 `['mysql-multi']['serverid']` default behaviour is to use a unique ID create from
 the IP address, however this allows manual overriding. Default to nil
-
 
 Additional attributes added due to the redesign of the community MySQL recipe.
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ as well as adding this code to your recipe:
 ```ruby
 
 mysql2_chef_gem 'default' do
+  client_version node['mysql-multi']['server_version']
   action :install
 end
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ the slave MySQL user, by default it is set to 'replicant'.
 best `bind_address` for mysql. Allowing you to set it to whatever is needed for
 your specific configuration.
 
+`['mysql-multi']['serverid']` default behaviour is to use a unique ID create from
+the IP address, however this allows manual overriding. Default to nil
+
+
 Additional attributes added due to the redesign of the community MySQL recipe.
 
 `['mysql-multi']['server_root_password']` sets root password for MySQL service.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,3 +27,4 @@ default['mysql-multi']['service_name'] = 'chef'
 default['mysql-multi']['server_version'] = '5.5'
 default['mysql-multi']['bind_address'] = '0.0.0.0'
 default['mysql-multi']['service_port'] = '3306'
+default['mysql-multi']['serverid'] = nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,4 +43,5 @@ end
 
 mysql2_chef_gem 'default' do
   action :install
+  client_version node['mysql-multi']['server_version']
 end

--- a/recipes/mysql_master.rb
+++ b/recipes/mysql_master.rb
@@ -20,11 +20,15 @@
 include_recipe node['mysql-multi']['install_recipe']
 include_recipe 'mysql-multi::_find_slaves'
 
-# creates unique serverid via ipaddress to an int
-require 'ipaddr'
-serverid = IPAddr.new node['ipaddress']
-serverid = serverid.to_i
-
+if node['mysql-multi']['serverid'].nil?
+  # creates unique serverid via ipaddress to an int
+  require 'ipaddr'
+  serverid = IPAddr.new node['ipaddress']
+  serverid = serverid.to_i
+else
+  serverid = node['mysql-multi']['serverid']
+end
+    
 # drop master.cnf configuration file
 mysql_config 'master replication' do
   config_name 'replication'

--- a/recipes/mysql_slave.rb
+++ b/recipes/mysql_slave.rb
@@ -20,10 +20,14 @@
 include_recipe node['mysql-multi']['install_recipe']
 include_recipe 'mysql-multi::_find_master'
 
-# creates unique serverid via ipaddress to an int
-require 'ipaddr'
-serverid = IPAddr.new node['ipaddress']
-serverid = serverid.to_i
+if node['mysql-multi']['serverid'].nil?
+  # creates unique serverid via ipaddress to an int
+  require 'ipaddr'
+  serverid = IPAddr.new node['ipaddress']
+  serverid = serverid.to_i
+else
+  serverid = node['mysql-multi']['serverid']
+end
 
 # drop slave.cnf configuration file
 mysql_config 'slave replication' do


### PR DESCRIPTION
**ServerID**
Using Vagrant / Virtualbox produced the same serverid across the master and slave (eth0 has the same IP address). Rather than fix the generation script, allow for manual overriding from default attribute.

**mysql2_chef_gem**
On Redhat/Centos, installing Chef Gem without a version includes the default MySQL 5.1 which is undesired. Include the client_version to avoid this and keep consistency (https://github.com/sinfomicien/mysql2_chef_gem#parameters)

**README comments**
Added a comment to README for previously added `install_recipe` attribute