### PR TITLE
mysqlm_slave_sync resource name is incorretly named

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ mysql-multi Cookbook CHANGELOG
 This file is used to list changes made in each version of the mysql-multi
 cookbook.
 
+v2.1.6 (2015-07-04)
+- Fixed bug with the resource name mysqlm_slave_sync
+
 v2.1.5 (2015-05-28)
 - Added a check for best_ip_for returning nil. That does not help anything.
 

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -8,6 +8,6 @@ if defined?(ChefSpec)
   end
 
   def mysqlm_slave_sync(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:mysql_slave_sync, :create, resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:mysqlm_slave_sync, :create, resource_name)
   end
 end

--- a/libraries/resource_slave_sync.rb
+++ b/libraries/resource_slave_sync.rb
@@ -2,7 +2,7 @@ class Chef
   class Resource
     # Sets up Mysql Slave server and connects them to master servers
     class MysqlmSlaveSync < Chef::Resource::LWRPBase
-      resource_name :mysql_slave_sync
+      resource_name :mysqlm_slave_sync
       actions :create
       default_action :create
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ description 'MySQL replication wrapper cookbook'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/rackspace-cookbooks/mysql-multi'
 issues_url 'https://github.com/rackspace-cookbooks/mysql-multi/issues'
-version '2.1.5' # bump this AFTER release, not in a PR or before
+version '2.1.6' # bump this AFTER release, not in a PR or before
 
 supports 'ubuntu'
 supports 'centos'


### PR DESCRIPTION
The recipe mysql_slave calls to mysqlm_slave_sync resource but in the definition the resource is named "mysql_slave_sync".

It generate the next error.

```
================================================================================
  Recipe Compile Error in /var/chef/cache/cookbooks/mysql-multi/recipes/mysql_slave.rb
  ================================================================================
  
  NoMethodError
  -------------
  No resource or method named `mysqlm_slave_sync' for `Chef::Recipe "mysql_slave"'
  
  Cookbook Trace:
  ---------------
    /var/chef/cache/cookbooks/mysql-multi/recipes/mysql_slave.rb:48:in `from_file'
  
  Relevant File Content:
  ----------------------
  /var/chef/cache/cookbooks/mysql-multi/recipes/mysql_slave.rb:
  
   41:      mysql_instance: node['mysql-multi']['service_name']
   42:    )
   43:    notifies :restart, "mysql_service[#{node['mysql-multi']['service_name']}]", :immediately
   44:    action :create
   45:  end
   46:  
   47:  # sync slaves to master
   48>> mysqlm_slave_sync 'slaves' do
   49:    replpasswd node['mysql-multi']['server_repl_password']
   50:    rootpasswd node['mysql-multi']['server_root_password']
   51:    master_ip node['mysql-multi']['master']
   52:  end
   53:  
   54:  tag('mysql_slave')
   55:  
```

This commit fix the problem.