### PR TITLE
Update user.my.cnf.erb to quote password

### DIFF
--- a/templates/default/user.my.cnf.erb
+++ b/templates/default/user.my.cnf.erb
@@ -5,11 +5,11 @@
 #
 
 [mysql]
-host=<%= @host %>
-user=<%= @user %>
-password=<%= @pass %>
+host="<%= @host %>"
+user="<%= @user %>"
+password="<%= @pass %>"
 
 [client]
-host=<%= @host %>
-user=<%= @user %>
-password=<%= @pass %>
+host="<%= @host %>"
+user="<%= @user %>"
+password="<%= @pass %>"

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -14,9 +14,9 @@ describe file('/etc/mysql-chef/conf.d') do
 end
 
 describe file('/root/.my.cnf') do
-  it { should contain('user=\'root\'').from('\[mysql\]').to('\[client\]') }
-  it { should contain('password=\'SillyRootPasswd\'').from('\[mysql\]').to('\[client\]') }
-  it { should contain('user=\'root\'').after('\[client\]') }
-  it { should contain('password=\'SillyRootPasswd\'').after('\[client\]') }
+  it { should contain('user="root"').from('\[mysql\]').to('\[client\]') }
+  it { should contain('password="SillyRootPasswd"').from('\[mysql\]').to('\[client\]') }
+  it { should contain('user="root"').after('\[client\]') }
+  it { should contain('password="SillyRootPasswd"').after('\[client\]') }
   it { should be_mode(600) }
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -14,9 +14,9 @@ describe file('/etc/mysql-chef/conf.d') do
 end
 
 describe file('/root/.my.cnf') do
-  it { should contain('user=root').from('\[mysql\]').to('\[client\]') }
-  it { should contain('password=SillyRootPasswd').from('\[mysql\]').to('\[client\]') }
-  it { should contain('user=root').after('\[client\]') }
-  it { should contain('password=SillyRootPasswd').after('\[client\]') }
+  it { should contain('user=\'root\'').from('\[mysql\]').to('\[client\]') }
+  it { should contain('password=\'SillyRootPasswd\'').from('\[mysql\]').to('\[client\]') }
+  it { should contain('user=\'root\'').after('\[client\]') }
+  it { should contain('password=\'SillyRootPasswd\'').after('\[client\]') }
   it { should be_mode(600) }
 end


### PR DESCRIPTION
When using complex values with symbols, they can be parsed incorrectly. Values as provided for the host, user and password have the potential to contain these characters and should be quoted to parse properly.