### PR TITLE
Fixing Rubocop error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,7 +31,7 @@ CyclomaticComplexity:
   Max: 10
 
 # Disable Single Space before first arg
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
   Enabled: false
 
 # Don't force a word array unless 5 elements


### PR DESCRIPTION
Error: The `Style/SingleSpaceBeforeFirstArg` cop has been renamed to `Style/SpaceBeforeFirstArg. 
(obsolete configuration found in /home/ubuntu/mysql-multi/.rubocop.yml, please update it)